### PR TITLE
bugfix: ->text-button requires ctx, is not 2-arity

### DIFF
--- a/src/components/widgets/player_modal.clj
+++ b/src/components/widgets/player_modal.clj
@@ -15,7 +15,8 @@
   (add-to-stage! ctx
                  (ui/->window {:title title
                                :rows [[(ui/->label text)]
-                                      [(ui/->text-button button-text
+                                      [(ui/->text-button ctx
+                                                         button-text
                                                          (fn [ctx]
                                                            (remove! (::modal (get-stage ctx)))
                                                            (on-click ctx)))]]


### PR DESCRIPTION
On death:
```
              components.context.effect-handler/eval9227/fn/fn  effect_handler.clj:   79
                  components.context.effect-handler/handle-tx!  effect_handler.clj:   70
                                    core.context/eval1116/fn/G         context.clj:   75
                 components.context.effect-handler/eval9227/fn  effect_handler.clj:   75
                                           clojure.core/reduce            core.clj: 6964
                                                           ...                         
              components.context.effect-handler/eval9227/fn/fn  effect_handler.clj:   79
                  components.context.effect-handler/handle-tx!  effect_handler.clj:   70
                                    core.context/eval1116/fn/G         context.clj:   75
                 components.context.effect-handler/eval9227/fn  effect_handler.clj:   75
                                           clojure.core/reduce            core.clj: 6964
                                                           ...                         
              components.context.effect-handler/eval9227/fn/fn  effect_handler.clj:   79
                  components.context.effect-handler/handle-tx!  effect_handler.clj:   70
                                    core.context/eval1116/fn/G         context.clj:   75
                 components.context.effect-handler/eval9227/fn  effect_handler.clj:   75
                                           clojure.core/reduce            core.clj: 6964
                                                           ...                         
              components.context.effect-handler/eval9227/fn/fn  effect_handler.clj:   79
                  components.context.effect-handler/handle-tx!  effect_handler.clj:   65
                                                           ...                         
components.widgets.player-modal/eval24662/do!-DOT-player-modal    player_modal.clj:   30
            components.widgets.player-modal/show-player-modal!    player_modal.clj:   18
                                                           ...                         
clojure.lang.ArityException: Wrong number of args (2) passed to: gdx.scene2d.ui/->text-button
 clojure.lang.ExceptionInfo: Error with transaction
    tx: [:tx/player-modal
     {:title "YOU DIED",
      :text "\nGood luck next time",
      :button-text ":(",
      :on-click
      #object[components.entity_state.player_dead$eval20202$enter_DOT_player_dead__20203$fn__20207 0x7f6469b1 "components.entity_state.player_dead$eval20202$enter_DOT_player_dead__20203$fn__20207@7f6469b1"]}]
 clojure.lang.ExceptionInfo: Error with transaction
    tx: #object[components.entity.state$send_event_BANG_$fn__19407 0x3a85d9d "components.entity.state$send_event_BANG_$fn__19407@3a85d9d"]
 clojure.lang.ExceptionInfo: Error with transaction
    tx: [:tx/event
     #<Atom@5586edf5: 
       {:position [32.5 71.5],
        :left-bottom [32.145832 71.166664],
        :width 0.7083333,
        :height 0.6666667,
        :half-width 0.35416666,
        :half-height 0.33333334,
        :radius 0.35416666,
        :collides? true,
        :z-order :z-order/ground,
        :rotation-angle 0,
        ...}>
     :kill]
 clojure.lang.ExceptionInfo: Error with transaction
    tx: [:effect.entity/damage #:damage{:min-max [10 10]}]
 clojure.lang.ExceptionInfo: Error with transaction
    tx: [:effect.entity/melee-damage true]
 clojure.lang.ExceptionInfo: Error with transaction
    tx: [:effect/target-entity
     {:entity-effects #:effect.entity{:melee-damage true}, :maxrange 0.5}]
 clojure.lang.ExceptionInfo: Error with transaction
    tx: [:tx/effect
     {:effect/source #<Atom@161451a4: 
                       {#, #, #, #, #, #, #, #, #, #, ...}>,
      :effect/target #<Atom@5586edf5: 
                       {#, #, #, #, #, #, #, #, #, #, ...}>,
      :effect/direction [0.97418135 -0.22576681]}
     #:effect{:target-entity {:entity-effects #, :maxrange 0.5}}]
 clojure.lang.ExceptionInfo: 
    entity/uid: 2
```